### PR TITLE
Correcting the Content-Type header Currently the documentation indicates that the `Content-Type` header should be `application/json-patch+json` for Patching a BC, but it really should be `application/merge-patch+json`.

### DIFF
--- a/rest_api/oapi/v1.BuildConfig.adoc
+++ b/rest_api/oapi/v1.BuildConfig.adoc
@@ -962,7 +962,7 @@ PATCH /oapi/v1/namespaces/$NAMESPACE/buildconfigs/$NAME HTTP/1.1
 Authorization: Bearer $TOKEN
 Accept: application/json
 Connection: close
-Content-Type: application/json-patch+json'
+Content-Type: application/merge-patch+json'
 
 {
   ...
@@ -977,7 +977,7 @@ $ curl -k \
     -d @- \
     -H "Authorization: Bearer $TOKEN" \
     -H 'Accept: application/json' \
-    -H 'Content-Type: application/json-patch+json' \
+    -H 'Content-Type: application/merge-patch+json' \
     https://$ENDPOINT/oapi/v1/namespaces/$NAMESPACE/buildconfigs/$NAME <<'EOF'
 {
   ...


### PR DESCRIPTION
I found this at the request of a customer but by manually running a patch command (using the `oc` cli tool) and looking at the full API call being made.

`application/json-patch+json` does not work but `application/merge-patch+json` does:

~~~
$ python
Python 2.7.5 (default, May 31 2018, 09:41:32) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-28)] on linux2
Type "help", "copyright", "credits" or "license" for more information. 
>>> import json
>>> import requests
>>> url ='https://test.example.com:443/oapi/v1/namespaces/test/buildconfigs/ruby-ex'
>>> token  = 'USER_TOKEN'
>>> headers = {'Authorization': 'Bearer ' + token, 'Accept': 'application/json', 'Content-Type':'application/json-patch+json'}
>>> body = json.dumps({"metadata": {"annotations": {"previous_version": "4"}}})
>>> r = requests.patch(url=url, data=body, headers=headers, verify=False)
/usr/lib/python2.7/site-packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
>>> print r.status_code
500
>>> print r.text()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'unicode' object is not callable
>>> print r.text
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"json: cannot unmarshal object into Go value of type jsonpatch.Patch","code":500}

>>> headers = {'Authorization': 'Bearer ' + token, 'Accept': 'application/json', 'Content-Type':'application/merge-patch+json'}
>>> r = requests.patch(url=url, data=body, headers=headers, verify=False)
>>> print r.text
{"kind":"BuildConfig","apiVersion":"v1","metadata":{"name":"ruby-ex","namespace":"test","selfLink":"/oapi/v1/namespaces/test/buildconfigs/ruby-ex","uid":"UID","resourceVersion":"212820","creationTimestamp":"2018-07-18T19:20:55Z","labels":{"app":"ruby-ex"},"annotations":{"openshift.io/generated-by":"OpenShiftNewApp","previous_version":"4"}},"spec":{"triggers":[{"type":"GitHub","github":{"secret":"l8eRJhMNg30m9M4ZPtya"}},{"type":"Generic","generic":{"secret":"aLn3og4jVBm4VX51M_Q5"}},{"type":"ConfigChange"},{"type":"ImageChange","imageChange":{"lastTriggeredImageID":"centos/ruby-22-centos7@sha256:a18c8706118a5c4c9f1adf045024d2abf06ba632b5674b23421019ee4d3edcae"}}],"runPolicy":"Serial","source":{"type":"Git","git":{"uri":"https://github.com/openshift/ruby-ex.git"}},"strategy":{"type":"Source","sourceStrategy":{"from":{"kind":"ImageStreamTag","name":"ruby-22-centos7:latest"}}},"output":{"to":{"kind":"ImageStreamTag","name":"ruby-ex:latest"}},"resources":{},"postCommit":{},"nodeSelector":null,"successfulBuildsHistoryLimit":5,"failedBuildsHistoryLimit":5},"status":{"lastVersion":1}}
~~~